### PR TITLE
[Integrate] connect the forget password api to forget password page

### DIFF
--- a/be/db/migrate/20220621072426_add_last_name_and_first_name_to_user.rb
+++ b/be/db/migrate/20220621072426_add_last_name_and_first_name_to_user.rb
@@ -1,6 +1,0 @@
-class AddLastNameAndFirstNameToUser < ActiveRecord::Migration[7.0]
-  def change
-    add_column :users, :lastname, :string
-    add_column :users, :firstname, :string
-  end
-end

--- a/be/db/migrate/20220621072622_add_is_admin_to_user.rb
+++ b/be/db/migrate/20220621072622_add_is_admin_to_user.rb
@@ -1,6 +1,0 @@
-class AddIsAdminToUser < ActiveRecord::Migration[7.0]
-  def change
-    add_column :users, :is_admin, :boolean, default: false
-    #Ex:- :default =>''
-  end
-end

--- a/fe/public/env.js
+++ b/fe/public/env.js
@@ -1,3 +1,3 @@
 window.env = {
-  "BASE_URL": "http://localhost:3000/"
+  "BASE_URL": "http://localhost:3000"
 };

--- a/fe/src/pages/SignUp/index.tsx
+++ b/fe/src/pages/SignUp/index.tsx
@@ -2,22 +2,35 @@ import React from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { useAppDispatch } from "../../redux/hooks";
 import { registerUser } from "../../redux/userSlice";
-import { Link, Navigate } from "react-router-dom";
-import { User } from "../Login";
 import {
   FormControl,
   FormLabel,
   Heading,
-  Text,
   Input,
   Button,
   Flex,
+  Text,
 } from "@chakra-ui/react";
 
-const SignupPage = () => {
+import { Link } from "react-router-dom";
+
+export interface User {
+  email: string;
+  password: string;
+}
+
+export interface registerParams {
+  email: string;
+  password: string;
+  lastname: string;
+  username: string;
+  firstname: string;
+}
+
+function SignupPage() {
   const dispatch = useAppDispatch();
-  const { register, handleSubmit } = useForm<User>();
-  const handleSubmitUser: SubmitHandler<User> = (data) => {
+  const { register, handleSubmit } = useForm<registerParams>();
+  const handleSubmitUser: SubmitHandler<registerParams> = (data) => {
     dispatch(registerUser(data));
   };
 
@@ -32,6 +45,24 @@ const SignupPage = () => {
             {...register("email", { required: "email is required" })}
             type="email"
           />
+          <FormLabel htmlFor="lastname">Last name</FormLabel>
+          <Input
+            id="lastname"
+            {...register("lastname", { required: "lastname is required" })}
+            type="text"
+          />
+          <FormLabel htmlFor="firstname">First name</FormLabel>
+          <Input
+            id="firstname"
+            {...register("firstname", { required: "first name is required" })}
+            type="text"
+          />
+          <FormLabel htmlFor="username">User name</FormLabel>
+          <Input
+            id="User name"
+            {...register("username", { required: "user name is required" })}
+            type="text"
+          />
           <FormLabel htmlFor="password">Password</FormLabel>
           <Input
             id="password"
@@ -42,15 +73,17 @@ const SignupPage = () => {
             Register
           </Button>
         </FormControl>
+        <Flex flexDirection={"column"}>
+          <Text fontSize="xs" my={5}>
+            Already have an account? |
+            <span>
+              <Link to="/login">Login</Link>
+            </span>
+          </Text>
+        </Flex>
       </form>
-      <Text mt={5} fontSize="xs">
-        already have an account?
-        <span>
-          <Link to="/login"> Login</Link>
-        </span>
-      </Text>
     </Flex>
   );
-};
+}
 
 export default SignupPage;

--- a/fe/src/redux/userSlice.ts
+++ b/fe/src/redux/userSlice.ts
@@ -2,15 +2,19 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { RootState } from "./store";
 import { elearningApiCall } from "../utils/railsApi";
 import { User } from "../pages/Login";
+import { registerParams } from "../pages/SignUp";
 
 export const registerUser = createAsyncThunk(
   "user/register_user",
-  async (data: User, { rejectWithValue, fulfillWithValue }) => {
+  async (data: registerParams, { rejectWithValue, fulfillWithValue }) => {
     try {
       const res = await elearningApiCall.post("/signup", {
         user: {
           email: data.email,
           password: data.password,
+          lastname: data.lastname,
+          firstname: data.firstname,
+          username: data.username,
         },
       });
       return fulfillWithValue(res.data.status.message);


### PR DESCRIPTION
### **Asana taks link**

https://app.asana.com/0/1202441287469383/1202441623452487/f

### **Commands**

`cd fe`  _get into the fe folder_

`npm i` _install dependencies_

`npm start` _start the server_

### **Pre condition**

- please create a new user to send an email to and reset the password using token
- click the forgot password page and send an email for token like so:

<img width="1067" alt="Screen Shot 2022-06-22 at 8 05 28 AM" src="https://user-images.githubusercontent.com/105702006/174950950-5cc2a197-4192-436b-a9ec-6f4f06364129.png">

- follow the instruction of resetting the password and you will be prompted to reset password page there you can change your password with the token you got from the email

### **Expected Output**

There should be an alert saying the password resetted


